### PR TITLE
plot_heatmap() options: clustering_distance_rows, clustering_distance_cols

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -149,8 +149,8 @@ plot_PCA <- function(x, norm_cts_type = "edger", assay_name="norm_log_cpm",
 #' @param rowdata_split character value of rowData colname for splitting
 #' @param clust_rows logical for whether rows should be clustered
 #' @param clust_cols logical for whether columns should be clustered
-#' @param clustering_distance_rows see 'clustering_distance_rows' in \code{\link[ComplexHeatmap]{ComplexHeatmap::Heatmap}}
-#' @param clustering_distance_columns see 'clustering_distance_columns' in \code{\link[ComplexHeatmap]{ComplexHeatmap::Heatmap}}
+#' @param clustering_distance_rows see 'clustering_distance_rows' in \code{\link[ComplexHeatmap]{Heatmap}}
+#' @param clustering_distance_columns see 'clustering_distance_columns' in \code{\link[ComplexHeatmap]{Heatmap}}
 #' @param grouped logical indicating whether the mean expression per group
 #'   should be shown.
 #' @param zscores logical indicating whether the expression matrix should be

--- a/R/misc.R
+++ b/R/misc.R
@@ -149,6 +149,8 @@ plot_PCA <- function(x, norm_cts_type = "edger", assay_name="norm_log_cpm",
 #' @param rowdata_split character value of rowData colname for splitting
 #' @param clust_rows logical for whether rows should be clustered
 #' @param clust_cols logical for whether columns should be clustered
+#' @param clustering_distance_rows see 'clustering_distance_rows' in \code{\link[ComplexHeatmap]{ComplexHeatmap::Heatmap}}
+#' @param clustering_distance_cols see 'clustering_distance_cols' in \code{\link[ComplexHeatmap]{ComplexHeatmap::Heatmap}}
 #' @param grouped logical indicating whether the mean expression per group
 #'   should be shown.
 #' @param zscores logical indicating whether the expression matrix should be
@@ -173,6 +175,8 @@ plot_heatmap <- function(x,
                          rowdata_split = NULL,
                          clust_rows = TRUE,
                          clust_cols = TRUE,
+                         clustering_distance_rows = "euclidean",
+                         clustering_distance_cols = "euclidean",
                          zscores = FALSE,
                          grouped = FALSE) {
   if(!is(x, "BbcSE")) stop("x is not a BbcSE object")
@@ -358,8 +362,10 @@ plot_heatmap <- function(x,
                                        cluster_column_slices = FALSE,
                                        cluster_rows = clust_rows,
                                        cluster_columns = clust_cols,
-                                       column_split = coldata_split,
+                                       clustering_distance_rows = clustering_distance_rows,
+                                       clustering_distance_columns = clustering_distance_columns,
                                        row_split = rowdata_split,
+                                       column_split = coldata_split,
                                        top_annotation = coldata_annot,
                                        right_annotation = rowdata_annot,
                                        row_title_rot = 0,

--- a/R/misc.R
+++ b/R/misc.R
@@ -149,8 +149,8 @@ plot_PCA <- function(x, norm_cts_type = "edger", assay_name="norm_log_cpm",
 #' @param rowdata_split character value of rowData colname for splitting
 #' @param clust_rows logical for whether rows should be clustered
 #' @param clust_cols logical for whether columns should be clustered
-#' @param clustering_distance_rows see 'clustering_distance_rows' in ComplexHeatmap::Heatmap
-#' @param clustering_distance_columns see 'clustering_distance_columns' in ComplexHeatmap::Heatmap
+#' @param clustering_distance_rows see 'clustering_distance_rows' in ComplexHeatmap::Heatmap()
+#' @param clustering_distance_columns see 'clustering_distance_columns' in ComplexHeatmap::Heatmap()
 #' @param grouped logical indicating whether the mean expression per group
 #'   should be shown.
 #' @param zscores logical indicating whether the expression matrix should be

--- a/R/misc.R
+++ b/R/misc.R
@@ -149,8 +149,8 @@ plot_PCA <- function(x, norm_cts_type = "edger", assay_name="norm_log_cpm",
 #' @param rowdata_split character value of rowData colname for splitting
 #' @param clust_rows logical for whether rows should be clustered
 #' @param clust_cols logical for whether columns should be clustered
-#' @param clustering_distance_rows see 'clustering_distance_rows' in \code{\link[ComplexHeatmap]{Heatmap}}
-#' @param clustering_distance_columns see 'clustering_distance_columns' in \code{\link[ComplexHeatmap]{Heatmap}}
+#' @param clustering_distance_rows see 'clustering_distance_rows' in ComplexHeatmap::Heatmap
+#' @param clustering_distance_columns see 'clustering_distance_columns' in ComplexHeatmap::Heatmap
 #' @param grouped logical indicating whether the mean expression per group
 #'   should be shown.
 #' @param zscores logical indicating whether the expression matrix should be

--- a/R/misc.R
+++ b/R/misc.R
@@ -150,7 +150,7 @@ plot_PCA <- function(x, norm_cts_type = "edger", assay_name="norm_log_cpm",
 #' @param clust_rows logical for whether rows should be clustered
 #' @param clust_cols logical for whether columns should be clustered
 #' @param clustering_distance_rows see 'clustering_distance_rows' in \code{\link[ComplexHeatmap]{ComplexHeatmap::Heatmap}}
-#' @param clustering_distance_cols see 'clustering_distance_cols' in \code{\link[ComplexHeatmap]{ComplexHeatmap::Heatmap}}
+#' @param clustering_distance_columns see 'clustering_distance_columns' in \code{\link[ComplexHeatmap]{ComplexHeatmap::Heatmap}}
 #' @param grouped logical indicating whether the mean expression per group
 #'   should be shown.
 #' @param zscores logical indicating whether the expression matrix should be
@@ -176,7 +176,7 @@ plot_heatmap <- function(x,
                          clust_rows = TRUE,
                          clust_cols = TRUE,
                          clustering_distance_rows = "euclidean",
-                         clustering_distance_cols = "euclidean",
+                         clustering_distance_columns = "euclidean",
                          zscores = FALSE,
                          grouped = FALSE) {
   if(!is(x, "BbcSE")) stop("x is not a BbcSE object")

--- a/man/plot_heatmap.Rd
+++ b/man/plot_heatmap.Rd
@@ -8,7 +8,9 @@ plot_heatmap(x, genes = rownames(x), de_method = "edger",
   assay_name = "norm_log_cpm", gene_labels = NULL,
   coldata_annot = NULL, coldata_split = NULL, rowdata_annot = NULL,
   rowdata_split = NULL, clust_rows = TRUE, clust_cols = TRUE,
-  zscores = FALSE, grouped = FALSE)
+  clustering_distance_rows = "euclidean",
+  clustering_distance_columns = "euclidean", zscores = FALSE,
+  grouped = FALSE)
 }
 \arguments{
 \item{x}{A BbcSE object}
@@ -34,6 +36,10 @@ batch-corrected data.}
 \item{clust_rows}{logical for whether rows should be clustered}
 
 \item{clust_cols}{logical for whether columns should be clustered}
+
+\item{clustering_distance_rows}{see 'clustering_distance_rows' in \code{\link[ComplexHeatmap]{ComplexHeatmap::Heatmap}}}
+
+\item{clustering_distance_columns}{see 'clustering_distance_columns' in \code{\link[ComplexHeatmap]{ComplexHeatmap::Heatmap}}}
 
 \item{zscores}{logical indicating whether the expression matrix should be
 converted to Z-scores}


### PR DESCRIPTION
add the following options from `ComplexHeatmap::Heatmap()` to `bbcRNA::plot_heatmap` so we can choose clustering distance method: 
1. `clustering_distance_rows`
2. `clustering_distance_cols`

We also want to test out the pull request method for team development.
@genomics-kl, please take a look at the documentation part of this request. I was able to test the function, which seems to be working ok, but I'm not super familiar with documentation in R/roxygen, so i'd appreciate your eye on this. thanks!
